### PR TITLE
마이페이지 전체글 연결 및 ui 수정

### DIFF
--- a/src/components/main/MemoryAction.jsx
+++ b/src/components/main/MemoryAction.jsx
@@ -1,9 +1,27 @@
 import { useState } from "react";
+import {useNavigate} from "react-router-dom";
 import LogoImage from "@/assets/image/logo-image.svg";
 import SelectGroupModal from "@/components/modal/SelectGroupModal";
+import NeedLoginToGuest from "@/components/modal/NeedLoginToGuest.jsx";
+import CreateGroup from "@/components/modal/CreateGroup.jsx";
 
-export default function MemoryActions({ widthClass = "flex-1", marginTop = "mt-0", onClickGroup }) {
+export default function MemoryActions({ widthClass = "flex-1", marginTop = "mt-0", isLogin }) {
+  const [showCreateGroupModal, setShowCreateGroupModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const [showMemoryModal, setShowMemoryModal] = useState(false);
+
+  const navigate = useNavigate();
+
+  const handleLoginModal = (type) => {
+    switch (type) {
+      case "register":
+        navigate("/login");
+        break;
+      case "guest":
+        setShowLoginModal(false);
+        break;
+    }
+  }
 
   return (
     <div className={`${widthClass} ${marginTop} h-auto px-3 py-6 bg-[#f4dffb]/20 rounded-lg border border-normalGray flex flex-col justify-between`}>
@@ -21,7 +39,7 @@ export default function MemoryActions({ widthClass = "flex-1", marginTop = "mt-0
       </div>
 
       <div className="flex flex-col gap-3 w-full">
-        <div className="bg-white rounded-md p-3 shadow-sm cursor-pointer" onClick={onClickGroup}>
+        <div className="bg-white rounded-md p-3 shadow-sm cursor-pointer" onClick={() => isLogin ? setShowLoginModal(true) : setShowCreateGroupModal(true)}>
           <span className="text-black text-sm font-normal">
             새로운 <span className="text-darkViolet">조각 그룹</span> 등록하기
           </span>
@@ -38,6 +56,12 @@ export default function MemoryActions({ widthClass = "flex-1", marginTop = "mt-0
             onClose={() => setShowMemoryModal(false)} 
             parentComponent="Main" 
           />
+        )}
+        {showLoginModal && (
+            <NeedLoginToGuest onClick={handleLoginModal} parentComponent="Main"/>
+        )}
+        {showCreateGroupModal && (
+            <CreateGroup onClose={() => setShowCreateGroupModal(false)} parentComponent="Main"/>
         )}
       </div>
     </div>

--- a/src/components/mypage/Reply.jsx
+++ b/src/components/mypage/Reply.jsx
@@ -1,8 +1,8 @@
 export default function ProfileEditCard({title, content}) {
   return (
-      <div className="w-[20vw] h-32 bg-white p-6 rounded-tl-2xl rounded-tr-2xl rounded-bl-sm rounded-br-2xl border-darkWhite">
-        <p className="text-xs text-darkViolet font-semibold">{title}</p>
-        <p className="text-xs font-semibold text-black pt-3">{content}</p>
+      <div className="w-[20vw] h-32 cursor-pointer bg-white p-6 rounded-tl-2xl rounded-tr-2xl rounded-bl-sm rounded-br-2xl border-darkWhite">
+        <p className="text-[18px] text-darkViolet font-semibold">{title}</p>
+        <p className="text-[16px] font-semibold text-black pt-3">{content}</p>
       </div>
   )
 }

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -87,16 +87,7 @@ export default function Main() {
     fetchRecentPosts();
   }, [])
 
-  const handleLoginModal = (type) => {
-    switch (type) {
-      case "register":
-        navigate("/login");
-        break;
-      case "guest":
-        setIsLoginModalOpen(false);
-        break;
-    }
-  }
+
 
   const handleGroupRegist = () => {
     !isLogin ? setIsLoginModalOpen(true) : setIsGroupMakeModalOpen(true)
@@ -197,7 +188,7 @@ export default function Main() {
           <MemoryActions widthClass="flex-1" marginTop="mt-[7vh]" onClickGroup={handleGroupRegist}/>
         </div>
         {isGroupMakeModalOpen && <CreateGroup onClose={() => setIsGroupMakeModalOpen(false)}/>}
-        {isLoginModalOpen && <NeedLoginToGuest onClick={handleLoginModal}/>}
+        {isLoginModalOpen && <NeedLoginToGuest isLogin={isLogin}/>}
       </div>
   );
 }

--- a/src/pages/MyCommentList.jsx
+++ b/src/pages/MyCommentList.jsx
@@ -27,15 +27,15 @@ export default function MyCommentList() {
   }, [currentPage]);
 
   if (isLoading) return <LoadingSpinner size={200} />;
-
+  
   return (
     <div className="w-full h-full p-6">
       <h2 className="text-2xl font-semibold mb-4">내가 작성한 댓글</h2>
       
       {replyData.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
           {replyData.map((reply, index) => (
-            <Reply key={index} {...reply} />
+            <Reply key={index} title={reply.post.title} content={reply.content} />
           ))}
         </div>
       ) : (

--- a/src/pages/MyPostList.jsx
+++ b/src/pages/MyPostList.jsx
@@ -21,16 +21,23 @@ export default function MyPostList() {
         
         if (response?.status === "success") {
           setPublicMemories(
-            response.data.posts.map((post) => ({
+            response.data?.posts.map((post) => ({
+              postId: post.postId || null,
+              groupId: post.group?.groupId || null,
               title: post.title || "제목 없음",
               content: post.content || "내용 없음",
-              tags: Array.isArray(post.tag) ? post.tag : [],
-              moment: post.moment ? new Date(post.moment).toLocaleDateString("ko-KR") : "날짜 없음",
-              createdAt: post.createdAt ? new Date(post.createdAt).toLocaleDateString("ko-KR") : "날짜 없음",
+              tag: Array.isArray(post.tag) ? post.tag : [],
+              moment: post.moment
+                  ? new Date(post.moment).toLocaleDateString("ko-KR")
+                  : "날짜 없음",
+              createdAt: post.createdAt
+                  ? new Date(post.createdAt).toLocaleDateString("ko-KR")
+                  : "날짜 없음",
+              imageUrl: post?.imageUrl ? `https://${post.imageUrl}` : null,
               likeCount: post.likeCount || 0,
               commentCount: post.commentCount || 0,
               author: post.author?.nickname || "알 수 없음",
-              groupName: post.group?.groupName || "그룹 없음",
+              location: post.group?.groupName || "그룹 없음",
             }))
           );
           setTotalPages(response.data.totalPages || 1);
@@ -54,9 +61,9 @@ export default function MyPostList() {
       <h2 className="text-2xl font-semibold mb-4">내가 작성한 글</h2>
       
       {publicMemories.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
           {publicMemories.map((memory, index) => (
-            <PublicPostCard key={index} {...memory} onClick={navigate('/')} />
+            <PublicPostCard key={index} {...memory} onClick={() => navigate('/')} />
           ))}
         </div>
       ) : (

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -24,6 +24,7 @@ export default function Mypage() {
   const articlescrollRef = useRef(null);
   const replyScrollRef = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLogin, setIsLogin] = useState(false);
   const [nickname, setNickname] = useState("예비 사용자");
   const [isTimeoutPassed, setIsTimeoutPassed] = useState(false);
   const [isModalVisible, setModalVisible] = useState(false);
@@ -39,13 +40,15 @@ export default function Mypage() {
   const handleViewAllComments = () => {
     navigate("/mypage/comments");
   };
-  
+
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
         const data = await userService.getUserInfo();
         setNickname(data.data.nickname);
+        setIsLogin(true);
       } catch {
+        setIsLogin(false);
         addToast("사용자 정보를 불러올 수 없습니다.");
       } finally {
         setIsLoading(false);
@@ -64,31 +67,32 @@ export default function Mypage() {
   useEffect(() => {
       const fetchMyPosts = async () => {
         try {
-          const response = await userService.getMyPosts(1, 5); 
+          const response = await userService.getMyPosts(1, 5);
           const posts = response?.data?.posts || [];
-    
+
           if (posts.length === 0) {
             setPublicMemories([]);
             return;
           }
-    
+
           setPublicMemories(
             posts.map((post) => ({
               postId: post.postId || null,
+              groupId: post.group?.groupId || null,
               title: post.title || "제목 없음",
               content: post.content || "내용 없음",
-              tags: Array.isArray(post.tag) ? post.tag : [], 
+              tag: Array.isArray(post.tag) ? post.tag : [],
               moment: post.moment
                 ? new Date(post.moment).toLocaleDateString("ko-KR")
                 : "날짜 없음",
               createdAt: post.createdAt
                 ? new Date(post.createdAt).toLocaleDateString("ko-KR")
                 : "날짜 없음",
+              imageUrl: post?.imageUrl ? `https://${post.imageUrl}` : null,
               likeCount: post.likeCount || 0,
               commentCount: post.commentCount || 0,
               author: post.author?.nickname || "알 수 없음",
-              groupName: post.group?.groupName || "그룹 없음",
-              isPublic: post.group?.isPublic ?? true,
+              location: post.group?.groupName || "그룹 없음",
             }))
           );
         } catch (error) {
@@ -159,7 +163,7 @@ export default function Mypage() {
 
       <div className="flex gap-10 max-w-[93%]">
         <ProfileEditCard onClickEdit={handleEdit} />
-        <MemoryAction />
+        <MemoryAction isLogin={!isLogin}/>
         <GroupCard />
       </div>
 
@@ -180,8 +184,8 @@ export default function Mypage() {
         <div ref={articlescrollRef} className="max-w-[85vw] overflow-x-auto scroll-smooth hide-scrollbar h-full">
           {publicMemories.length > 0 ? (
             <div className="grid grid-flow-col gap-3 w-max">
-              {publicMemories.map((memory, index) => (
-                <PublicPostCard key={index} id={index + 1} group={1} {...memory} />
+              {publicMemories.map((memory) => (
+                <PublicPostCard key={memory.postId} id={memory.postId} group={memory.groupId} {...memory} />
               ))}
             </div>
           ) : (


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #58

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?
마이페이지 내가 작성한 글 목록 조회 및 전체글 클릭시 이동되도록 연동했습니다. 
-


## 💡 해결한 이슈 목록

- [x] 전체글 선택시, /mypage/posts, /mypage/comment 각각 이동되게 했습니다.
- [x] /mypage/posts로 이동시 메인화면으로 바로 이동되어 해당 부분 수정했습니다. 
- [x] 마이페이지에서 내가 작성한 글 조회되도록 연동했습니다. 


## ✅ 변경사항

- 전체 글  및 댓글 조회 ui를 보기 좋게 바꿨습니다.
- MemoryAction카드 컴포넌트 안에서, 조각집 만들러가기 버튼을 처리하도록 코드 수정했습니다. 

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

![image](https://github.com/user-attachments/assets/fd517ba5-2f8f-44ef-90b2-a5b003501593)

내가 작성한 글
![image](https://github.com/user-attachments/assets/d47f4ad8-90cf-447a-b106-40b7543d067b)

내가 작성한 댓글 
![image](https://github.com/user-attachments/assets/4a5ce644-4dc7-4680-b028-07ae0b251947)
