### PR TITLE
비로그인시, 로그인 팝업띄우도록 작업

### DIFF
--- a/src/components/group/GroupTab.jsx
+++ b/src/components/group/GroupTab.jsx
@@ -1,19 +1,37 @@
 import { useState } from "react";
-import { useSearchParams, useLocation } from "react-router-dom";
+import {useSearchParams, useLocation, useNavigate} from "react-router-dom";
 import Tab from "@/components/common/Tab";
 import { groupTabList, GROUP_PARAMS } from "@/utils/constants";
 import CreateGroup from "@/components/modal/CreateGroup"; 
-import CreateMemory from "@/components/modal/CreateMemory"; 
+import CreateMemory from "@/components/modal/CreateMemory";
+import useValidateLogin from "@/hooks/useValidateLogin.js";
+import NeedLoginToGuest from "@/components/modal/NeedLoginToGuest.jsx";
+
 export default function GroupTab() {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isShowLoginModal, setIsShowLoginModal] = useState(false);
   const [isSecondModalOpen, setIsSecondModalOpen] = useState(false);
   const tabName = searchParams.get(GROUP_PARAMS) || "Public";
+
+  const navigate = useNavigate();
+  const {isLogin} = useValidateLogin();
 
   const handleChangeTab = (type) => {
     setSearchParams({ [GROUP_PARAMS]: type });
   };
+
+  const handleLoginModal = (type) => {
+    switch (type) {
+      case "register":
+        navigate("/login");
+        break;
+      case "guest":
+        setIsShowLoginModal(false);
+        break;
+    }
+  }
 
   const isGroupDetailPage = location.pathname.includes("/group/");
 
@@ -29,7 +47,7 @@ export default function GroupTab() {
           onClick={() =>
             isGroupDetailPage
               ? setIsSecondModalOpen(true)
-              : setIsModalOpen(true)
+              : isLogin ? setIsModalOpen(true) : setIsShowLoginModal(true)
           }
           className="cursor-pointer whitespace-pre px-4 pb-[19px] text-center text-normalGray hover:text-normalGray-hover active:text-normalGray-active"
         >
@@ -38,6 +56,7 @@ export default function GroupTab() {
       </Tab>
       {isModalOpen && <CreateGroup onClose={() => setIsModalOpen(false)} />}
       {isSecondModalOpen && <CreateMemory onClose={() => setIsSecondModalOpen(false)} />}
+      {isShowLoginModal && <NeedLoginToGuest onClick={handleLoginModal}/>}
     </>
   );
 }

--- a/src/components/main/MemoryAction.jsx
+++ b/src/components/main/MemoryAction.jsx
@@ -39,13 +39,13 @@ export default function MemoryActions({ widthClass = "flex-1", marginTop = "mt-0
       </div>
 
       <div className="flex flex-col gap-3 w-full">
-        <div className="bg-white rounded-md p-3 shadow-sm cursor-pointer" onClick={() => isLogin ? setShowLoginModal(true) : setShowCreateGroupModal(true)}>
+        <div className="bg-white rounded-md p-3 shadow-sm cursor-pointer" onClick={() => !isLogin ? setShowLoginModal(true) : setShowCreateGroupModal(true)}>
           <span className="text-black text-sm font-normal">
             새로운 <span className="text-darkViolet">조각 그룹</span> 등록하기
           </span>
         </div>
 
-        <div className="bg-white rounded-md p-3 shadow-sm cursor-pointer" onClick={() => setShowMemoryModal(true)}>
+        <div className="bg-white rounded-md p-3 shadow-sm cursor-pointer" onClick={() => !isLogin ? setShowLoginModal(true) : setShowMemoryModal(true)}>
           <span className="text-[#2a2a2a] text-sm font-normal">
             새로운 <span className="text-darkViolet">추억</span> 기록하기
           </span>

--- a/src/components/mypage/GroupCard.jsx
+++ b/src/components/mypage/GroupCard.jsx
@@ -3,10 +3,12 @@ import GroupList from "@/components/mypage/GroupList.jsx";
 import userService from "@/services/user/userService";
 import { useToast } from "@/hooks/useToast";
 import DummyImg from "@/assets/image/profile-basic2.svg";
+import useValidateLogin from "@/hooks/useValidateLogin.js";
 
 export default function GroupCard() {
   const [groups, setGroups] = useState([]);
   const addToast = useToast();
+  const {isLogin} = useValidateLogin();
 
   useEffect(() => {
     const fetchGroups = async () => {
@@ -20,7 +22,7 @@ export default function GroupCard() {
 
         setGroups(groupList);
       } catch {
-        addToast("내가 속한 그룹 목록 불러오기에 실패했습니다.");
+        if(isLogin) addToast("내가 속한 그룹 목록 불러오기에 실패했습니다.");
       }
     };
 

--- a/src/components/notification/Notification.jsx
+++ b/src/components/notification/Notification.jsx
@@ -3,10 +3,12 @@ import { X, Trash2, ChevronRight } from "lucide-react";
 import { useToast } from "@/hooks/useToast";
 import TimeIcon from "@/assets/icon/notification/time.svg";
 import notificationService from "@/services/notification/notificationService";
+import useValidateLogin from "@/hooks/useValidateLogin.js";
 
 export default function Notification({ onClose }) {
   const [notifications, setNotifications] = useState([]);
   const addToast = useToast();
+  const {isLogin} = useValidateLogin();
 
   useEffect(() => {
     const fetchNotifications = async () => {
@@ -14,7 +16,7 @@ export default function Notification({ onClose }) {
         const data = await notificationService.getNotification();
         setNotifications(data || []);
       } catch (error) {
-        addToast(error.message);
+        if(isLogin) addToast(error.message);
       }
     };
 

--- a/src/hooks/useValidateLogin.js
+++ b/src/hooks/useValidateLogin.js
@@ -1,0 +1,15 @@
+import {useEffect, useState} from "react";
+
+export default function useValidateLogin() {
+  const [isLogin, setIsLogin] = useState(!!localStorage.getItem("accessToken"));
+
+  useEffect(() => {
+    const handleStorageToken = () => {
+      setIsLogin(!!localStorage.getItem("accessToken"));
+    };
+
+    handleStorageToken();
+  }, []);
+
+  return {isLogin, setIsLogin};
+}

--- a/src/pages/Group.jsx
+++ b/src/pages/Group.jsx
@@ -18,6 +18,8 @@ import SearchBar from "@/components/common/SearchBar";
 import SearchButton from "@/components/common/SearchButton";
 import Select from "@/components/common/Select";
 
+import NeedLoginToGuest from "@/components/modal/NeedLoginToGuest.jsx";
+
 const GROUP_PARAMS = "group";
 
 const options = [
@@ -29,6 +31,7 @@ const options = [
 
 
 export default function Group() {
+  const [isLogin, setLogin] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState("");
@@ -41,6 +44,7 @@ export default function Group() {
   const [selectedGroupId, setSelectedGroupId] = useState(null);
   const [searchResult, setSearchResult] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [isShowLogin, setIsShowLogin] = useState(false);
   const navigate = useNavigate();
   const tabName = searchParams.get(GROUP_PARAMS) || "Public";
   const isPublic = tabName === "Public";
@@ -51,8 +55,10 @@ export default function Group() {
       try {
         const userInfo = await userService.getUserInfo();
         setMyId(userInfo.data.id);
+        setLogin(true);
       } catch {
-        addToast("사용자 정보를 불러오는 중 오류가 발생했습니다.");
+        setLogin(false);
+        if(isLogin) addToast("사용자 정보를 불러오는 중 오류가 발생했습니다.");
       }
     };
   
@@ -78,7 +84,7 @@ export default function Group() {
           throw new Error("그룹 목록 조회 실패");
         }
       } catch {
-        addToast("그룹 목록 조회에 실패했습니다.");
+        if(isLogin) addToast("그룹 목록 조회에 실패했습니다.");
       }
     };
 
@@ -88,6 +94,17 @@ export default function Group() {
   useEffect(() => {
     setSortBy(searchParams.get("sortBy") || "mostLiked");
   }, [searchParams]);
+
+  const handleLoginModal = (type) => {
+    switch (type) {
+      case "register":
+        navigate("/login");
+        break;
+      case "guest":
+        setIsShowLogin(false);
+        break;
+    }
+  }
   
   const handleSearch = async () => {
     if (!searchTerm.trim()) {
@@ -109,7 +126,7 @@ export default function Group() {
         throw new Error("검색 실패");
       }
     } catch {
-      addToast("검색 결과를 불러오는 중 오류가 발생했습니다.");
+      if(isLogin) addToast("검색 결과를 불러오는 중 오류가 발생했습니다.");
     }
   };
   
@@ -151,7 +168,7 @@ export default function Group() {
       navigate(`/group/${groupId}`);
 
     } catch {
-      addToast("그룹 정보 조회 중 오류가 발생했습니다.");
+      if(isLogin) addToast("그룹 정보 조회 중 오류가 발생했습니다.");
     }
   };
   
@@ -256,7 +273,7 @@ export default function Group() {
             </p>
             <p className="text-sm text-gray-400">가장 먼저 그룹을 만들어보세요!</p>
             {!isSearching && (
-              <button onClick={() => setIsModalOpen(true)}
+              <button onClick={() => isLogin ? setIsModalOpen(true) : setIsShowLogin(true)}
                       className="mt-4 px-5 py-2 bg-normalViolet hover:bg-normalViolet-hover active:bg-normalViolet-active text-white text-sm font-medium rounded-md">
                 그룹 만들기
               </button>
@@ -282,6 +299,7 @@ export default function Group() {
           onPageChange={setCurrentPage}
         />
       </div>
+      {isShowLogin && <NeedLoginToGuest onClick={handleLoginModal}/>}
     </div>
   );
 }

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -38,7 +38,7 @@ export default function Main() {
         setIsLogin(true);
       } catch {
         setIsLogin(false);
-        addToast("사용자 정보를 불러올 수 없습니다.");
+        if(isLogin) addToast("사용자 정보를 불러올 수 없습니다.");
       }
     };
 
@@ -60,7 +60,7 @@ export default function Main() {
           throw new Error("그룹 목록 조회 실패");
         }
       } catch {
-        addToast("그룹 목록 조회에 실패했습니다.");
+        if(isLogin) addToast("그룹 목록 조회에 실패했습니다.");
       }
     };
 
@@ -78,7 +78,7 @@ export default function Main() {
           throw new Error("내가 작성한 글 목록 조회 실패");
         }
       } catch {
-        addToast("최근에 작성한 글 조회에 실패했습니다.");
+        if(isLogin) addToast("최근에 작성한 글 조회에 실패했습니다.");
       }
     }
 
@@ -93,6 +93,17 @@ export default function Main() {
 
   const handleRecentNotice = () => {
     navigate("/notice/20")
+  }
+
+  const handleLoginModal = (type) => {
+    switch (type) {
+      case "register":
+        navigate("/login");
+        break;
+      case "guest":
+        setIsLoginModalOpen(false);
+        break;
+    }
   }
 
   return (
@@ -154,8 +165,7 @@ export default function Main() {
                 <span className="text-black text-base font-semibold">최근에 내가 작성한 </span>
                 <span className="text-darkViolet text-base font-semibold">추억 글</span>
               </div>
-              <div
-                  className="cursor-pointer text-right text-normalGray hover:text-normalGray-hover active:text-normalGray-active text-sm font-semibold">
+              <div className="cursor-pointer text-right text-normalGray hover:text-normalGray-hover active:text-normalGray-active text-sm font-semibold" onClick={() => !isLogin ? setIsLoginModalOpen(true) : navigate('mypage/posts')}>
                 전체 글 보러가기
               </div>
             </div>
@@ -186,7 +196,7 @@ export default function Main() {
           <MemoryActions widthClass="flex-1" marginTop="mt-[7vh]" onClickGroup={handleGroupRegist}/>
         </div>
         {isGroupMakeModalOpen && <CreateGroup onClose={() => setIsGroupMakeModalOpen(false)}/>}
-        {isLoginModalOpen && <NeedLoginToGuest isLogin={isLogin}/>}
+        {isLoginModalOpen && <NeedLoginToGuest onClick={handleLoginModal}/>}
       </div>
   );
 }

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -9,6 +9,7 @@ import GroupCard from "@/components/mypage/GroupCard.jsx";
 import Reply from "@/components/mypage/Reply.jsx";
 import EditProfile from "@/components/modal/EditProfile.jsx";
 import PassWordChange from "@/components/modal/PasswordChange.jsx";
+import NeedLoginToGuest from "@/components/modal/NeedLoginToGuest.jsx";
 
 import userService from "@/services/user/userService";
 
@@ -25,6 +26,7 @@ export default function Mypage() {
   const replyScrollRef = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isLogin, setIsLogin] = useState(false);
+  const [isShowLoginModal, setIsShowLoginModal] = useState(!isLogin);
   const [nickname, setNickname] = useState("예비 사용자");
   const [isTimeoutPassed, setIsTimeoutPassed] = useState(false);
   const [isModalVisible, setModalVisible] = useState(false);
@@ -41,6 +43,17 @@ export default function Mypage() {
     navigate("/mypage/comments");
   };
 
+  const handleLoginModal = (type) => {
+    switch (type) {
+      case "register":
+        navigate("/login");
+        break;
+      case "guest":
+        navigate("/");
+        setIsShowLoginModal(false);
+        break;
+    }
+  }
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
@@ -49,7 +62,7 @@ export default function Mypage() {
         setIsLogin(true);
       } catch {
         setIsLogin(false);
-        addToast("사용자 정보를 불러올 수 없습니다.");
+        if(isLogin) addToast("사용자 정보를 불러올 수 없습니다.");
       } finally {
         setIsLoading(false);
       }
@@ -97,7 +110,7 @@ export default function Mypage() {
           );
         } catch (error) {
           console.error("내가 작성한 글 불러오기 실패:", error);
-          addToast("내가 작성한 글을 불러오는 데 실패했습니다.");
+          if(isLogin) addToast("내가 작성한 글을 불러오는 데 실패했습니다.");
         }
       };
     
@@ -120,7 +133,7 @@ export default function Mypage() {
         );
       } catch (error) {
         console.error("내가 작성한 댓글 불러오기 실패:", error);
-        if (error.response?.status !== 200) {
+        if (error.response?.status !== 200 && isLogin) {
           addToast("내가 작성한 댓글을 불러오는 데 실패했습니다.");
         }
       }
@@ -244,6 +257,7 @@ export default function Mypage() {
         <EditProfile id={"gildeong32"} nickname={"홍길동"} onClose={() => setModalVisible(false)} onVerfiyChange={handleVerfiyChange} />
       )}
       {isSecondeModalVisible && <PassWordChange onClose={() => setSecondeModalVisible(false)} />}
+      {isShowLoginModal && <NeedLoginToGuest onClick={handleLoginModal}/>}
     </div>
   );
 }

--- a/src/pages/Scrap.jsx
+++ b/src/pages/Scrap.jsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 
 import {useToast} from "@/hooks/useToast.js";
 
+
 import scrapService from "@/services/scrap/scrapService.js";
 
 import NoScrapIcon from "@/assets/icon/scrap/no-scrap.svg";
@@ -42,7 +43,6 @@ export default function Scrap () {
   /** 로그인 유무 판단 **/
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
-
     if (!token) {
       setIsLogin(false);
     } else {
@@ -68,7 +68,7 @@ export default function Scrap () {
         }
 
       } catch{
-        addToast("스크랩한 추억글 조회에 실패했습니다.");
+        if(isLogin) addToast("스크랩한 추억글 조회에 실패했습니다.");
       }
     }
 


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #62

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?
비로그인일때 접속하면 로그인 팝업이 뜨도록 작업했습니다. 
-


## 💡 해결한 이슈 목록

- [x] 비로그인 일때 로그인 팝업이 뜨도록 진행했습니다.
- [x] 전체글보기 선택시, 전체글 보기로 넘어가게 진행했습니다. 
- [x] 로그인 유무를 판독하는 useValidateLogin 함수를 hooks에 만들었습니다.
- [x] 로그인일때만 데이터 오류 팝업뜨도록 수정했습니다. 


## ✅ 변경사항
비로그인

### 아래 상황에서 로그인 팝업이 뜹니다.
- 스크랩 페이지, 마이페이지 이동시
- 그룹 만들기, 조각그룹 만들기, 추억글 작성하기 선택시, 전체글 보러가기 선택시

### 아래는 기능이 정상적으로 동작합니다.
- 공개 그룹 목록 보러가기, 공지사항, 공지사항 상세보기, 메인화면

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video
변경사항에 조건별 로그인 팝업 정리했습니다. 

