### PR TITLE
게시글, 추억글 등록 삭제시 바로 반영되도록 변경 

### DIFF
--- a/src/components/modal/EditMemory.jsx
+++ b/src/components/modal/EditMemory.jsx
@@ -76,6 +76,8 @@ export default function EditMemory({ post, onClose, onUpdate }) {
     if (!post || !post.postId) {
       addToast("수정할 게시글 정보가 없습니다.");
       return;
+    } else{
+      addToast("게시글 수정이 완료됬습니다.");
     }
   
     const formDataToSend = new FormData();

--- a/src/pages/Group.jsx
+++ b/src/pages/Group.jsx
@@ -89,7 +89,7 @@ export default function Group() {
     };
 
     fetchGroupList();
-  }, [isPublic, sortBy, currentPage, isSearching]);
+  }, [isPublic, sortBy, currentPage, isSearching, groupData]);
 
   useEffect(() => {
     setSortBy(searchParams.get("sortBy") || "mostLiked");

--- a/src/pages/GroupDetail.jsx
+++ b/src/pages/GroupDetail.jsx
@@ -93,7 +93,7 @@ export default function GroupDetail() {
     };
     fetchGroupDetail();
     fetchPosts();
-  }, [groupId]); 
+  }, [groupId, publicMemories]);
   
   const fetchPosts = async () => {
     try {

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -106,6 +106,17 @@ export default function Main() {
     }
   }
 
+  const decodeImageUrl = (url) => {
+    if (!url) return null;
+
+    try {
+      const decodedUrl = decodeURIComponent(url);
+      return `https://d1up383l0okfvw.cloudfront.net/${decodedUrl}`;
+    } catch {
+      return `https://d1up383l0okfvw.cloudfront.net/${url}`;
+    }
+  };
+
   return (
       <div className="w-full h-full pt-3 pb-7 overflow-auto">
         <div className="flex items-center mb-1">
@@ -134,7 +145,7 @@ export default function Main() {
                           key={group.groupId}
                           title={group.groupName}
                           description={group.description}
-                          image={group.image}
+                          image={decodeImageUrl(group.imageUrl)}
                           picturecount={group.postCount}
                           emotioncount={group.likeCount}
                           badgecount={group.badgecount}

--- a/src/pages/MemoryPost.jsx
+++ b/src/pages/MemoryPost.jsx
@@ -43,7 +43,7 @@ export default function MemoryPost() {
     if (postId) {
       fetchScrapStatus();
     }
-  }, [postId]);
+  }, [postId, post]);
   
   useEffect(() => {
     const fetchPostDetail = async () => {

--- a/src/pages/MyPostList.jsx
+++ b/src/pages/MyPostList.jsx
@@ -54,7 +54,7 @@ export default function MyPostList() {
       <h2 className="text-2xl font-semibold mb-4">내가 작성한 글</h2>
       
       {publicMemories.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
           {publicMemories.map((memory, index) => (
             <PublicPostCard key={index} {...memory} onClick={() => navigate('/')} />
           ))}

--- a/src/pages/MyPostList.jsx
+++ b/src/pages/MyPostList.jsx
@@ -18,26 +18,19 @@ export default function MyPostList() {
     const fetchMyPosts = async () => {
       try {
         const response = await userService.getMyPosts(currentPage, 10);
-        
         if (response?.status === "success") {
           setPublicMemories(
             response.data?.posts.map((post) => ({
-              postId: post.postId || null,
-              groupId: post.group?.groupId || null,
+              id: post.postId || null,
               title: post.title || "제목 없음",
-              content: post.content || "내용 없음",
+              author: post.author?.nickname || "알 수 없음",
+              groupId: post.group?.groupId || null,
+              location: post.group?.groupName || "그룹 없음",
+              moment: post.moment ? new Date(post.moment).toLocaleDateString("ko-KR") : "날짜 없음",
               tag: Array.isArray(post.tag) ? post.tag : [],
-              moment: post.moment
-                  ? new Date(post.moment).toLocaleDateString("ko-KR")
-                  : "날짜 없음",
-              createdAt: post.createdAt
-                  ? new Date(post.createdAt).toLocaleDateString("ko-KR")
-                  : "날짜 없음",
               imageUrl: post?.imageUrl ? `https://${post.imageUrl}` : null,
               likeCount: post.likeCount || 0,
               commentCount: post.commentCount || 0,
-              author: post.author?.nickname || "알 수 없음",
-              location: post.group?.groupName || "그룹 없음",
             }))
           );
           setTotalPages(response.data.totalPages || 1);

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -26,7 +26,6 @@ export default function Mypage() {
   const replyScrollRef = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isLogin, setIsLogin] = useState(false);
-  const [isShowLoginModal, setIsShowLoginModal] = useState(!isLogin);
   const [nickname, setNickname] = useState("예비 사용자");
   const [isTimeoutPassed, setIsTimeoutPassed] = useState(false);
   const [isModalVisible, setModalVisible] = useState(false);
@@ -50,7 +49,6 @@ export default function Mypage() {
         break;
       case "guest":
         navigate("/");
-        setIsShowLoginModal(false);
         break;
     }
   }
@@ -257,7 +255,7 @@ export default function Mypage() {
         <EditProfile id={"gildeong32"} nickname={"홍길동"} onClose={() => setModalVisible(false)} onVerfiyChange={handleVerfiyChange} />
       )}
       {isSecondeModalVisible && <PassWordChange onClose={() => setSecondeModalVisible(false)} />}
-      {isShowLoginModal && <NeedLoginToGuest onClick={handleLoginModal}/>}
+      {!isLogin && <NeedLoginToGuest onClick={handleLoginModal}/>}
     </div>
   );
 }


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->
Closes #73

<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->
## 🔎 What is this PR?
게시글, 추억글 등록 삭제시 바로 반영되도록 변경 
-


## 💡 해결한 이슈 목록

- [x] 게시글 등록 삭제시 바로 반영되도록 해결
- [x] 메인페이지에서 그룹 카드 이미지 받아오도록 해결
- [x] 마이페이지에서 로그인 상태임에도 로그인 창 뜨는 오류 해결 
- [x] 전체글 보기에서도 변경된 컴포넌트 props 맞게 구조 변경했습니다 .


## ✅ 변경사항

- 게시글 수정 시 수정이 완료되었습니다 라는 토스트 메시지 추가했습니다. 


<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
## 📷 Screenshots or Video

![image](https://github.com/user-attachments/assets/3d703f91-35ff-4ef0-9fc2-d653fefba132)


